### PR TITLE
Add overlay style for modal

### DIFF
--- a/src/app/styles.js
+++ b/src/app/styles.js
@@ -5,7 +5,8 @@ const styles = {
     flexFlow: 'column nowrap'
   },
   modal: {
-    content: { padding: 0, bottom: 'auto' }
+    content: { padding: 0, bottom: 'auto' },
+    overlay: { zIndex: 1 }
   },
   window: {
     width: 'auto', height: 'auto'


### PR DESCRIPTION
Currently inspector buttons always keep on top:
![2016-05-03 10 00 55](https://cloud.githubusercontent.com/assets/3001525/14973223/b1e43614-1117-11e6-8eb8-b0642c5b8f8b.png)