### PR TITLE
fix lint error

### DIFF
--- a/src/app/containers/App.js
+++ b/src/app/containers/App.js
@@ -18,6 +18,7 @@ export default class App extends Component {
   static propTypes = {
     selectMonitor: PropTypes.string,
     testTemplates: PropTypes.array,
+    useCodemirror: PropTypes.bool,
     selectedTemplate: PropTypes.number,
     socketOptions: PropTypes.shape({
       hostname: PropTypes.string,


### PR DESCRIPTION
```
src/app/containers/App.js
  56:35  error  'useCodemirror' is missing in props validation  react/prop-types

✖ 1 problem (1 error, 0 warnings)
```