### PR TITLE
Move react/react-dom to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,9 @@
     "mocha": "^2.3.4",
     "mock-local-storage": "^1.0.2",
     "raw-loader": "^0.5.1",
-    "react-addons-test-utils": "^15.0.2",
+    "react": "^15.1.0",
+    "react-addons-test-utils": "^15.1.0",
+    "react-dom": "^15.1.0",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",
     "redbox-react": "^1.2.0",
@@ -86,9 +88,7 @@
     "chrome-storage-local": "^0.1.6",
     "jsan": "^3.1.2",
     "material-ui": "^0.15.1",
-    "react": "^15.1.0",
     "react-addons-shallow-compare": "^15.1.0",
-    "react-dom": "^15.1.0",
     "react-icons": "^2.0.1",
     "react-redux": "^4.0.6",
     "react-switcher": "^1.0.2",
@@ -104,5 +104,9 @@
     "redux-slider-monitor": "^1.0.6",
     "redux-thunk": "^1.0.3",
     "socketcluster-client": "^4.3.17"
+  },
+  "peerDependencies": {
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "chrome-storage-local": "^0.1.6",
     "jsan": "^3.1.2",
     "material-ui": "^0.15.1",
-    "react-addons-shallow-compare": "^15.1.0",
     "react-icons": "^2.0.1",
     "react-redux": "^4.0.6",
     "react-switcher": "^1.0.2",

--- a/src/app/components/Button.js
+++ b/src/app/components/Button.js
@@ -1,7 +1,7 @@
 // Based on https://github.com/gaearon/redux-devtools-log-monitor/blob/master/src/LogMonitorButton.js
 
 import React, { Component, PropTypes } from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
+import shallowCompare from 'react/lib/shallowCompare';
 import * as themes from 'redux-devtools-themes';
 import brighten from 'redux-devtools-log-monitor/lib/brighten';
 import styles from '../styles';

--- a/src/app/components/Instances.js
+++ b/src/app/components/Instances.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
-import shallowCompare from 'react-addons-shallow-compare';
+import shallowCompare from 'react/lib/shallowCompare';
 import styles from '../styles';
 
 export default class Instances extends Component {


### PR DESCRIPTION
Currently it will throw `Invariant Violation: addComponentAsRefTo(...): Only a ReactOwner can have refs` error if we use npm2 install this module. (will has two react module)

Also add react/react-dom to devDependencies for app build.