### PR TITLE
Fix SELECT_INSTANCE for autoselect instances

### DIFF
--- a/src/app/reducers/instances.js
+++ b/src/app/reducers/instances.js
@@ -219,7 +219,6 @@ export default function instances(state = initialState, action) {
     case TOGGLE_SYNC:
       return { ...state, sync: !state.sync };
     case SELECT_INSTANCE:
-      if (!state.options[action.selected]) return state;
       return { ...state, selected: action.selected, sync: false };
     case REMOVE_INSTANCE:
       return removeState(state, action.id);


### PR DESCRIPTION
Currently the selected instance cannot back to `Autoselect instances`, it will dispatch action `{ type: SELECT_INSTANCE, selected: null }` and `instances.selected` will not change to `null`.