### PR TITLE
Support monitor reducers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,7 @@
     "prefer-const": 0,
     "comma-dangle": 0,
     "id-length": 0,
+    "no-use-before-define": 0,
     "indent": [2, 2, {"SwitchCase": 1}],
     "new-cap": [2, { "capIsNewExceptions": ["Test"] }]
   },

--- a/src/app/actions/index.js
+++ b/src/app/actions/index.js
@@ -5,8 +5,17 @@ import {
 } from '../constants/actionTypes';
 import { RECONNECT } from '../constants/socketActionTypes';
 
+let monitorReducer;
+let monitorProps = {};
+
 export function liftedDispatch(action) {
-  if (action.type[0] === '@') return { type: MONITOR_ACTION, action };
+  if (action.type[0] === '@') {
+    if (action.type === '@@INIT_MONITOR') {
+      monitorReducer = action.update;
+      monitorProps = action.monitorProps;
+    }
+    return { type: MONITOR_ACTION, action, monitorReducer, monitorProps };
+  }
   return { type: LIFTED_ACTION, message: 'DISPATCH', action };
 }
 

--- a/src/app/containers/App.js
+++ b/src/app/containers/App.js
@@ -30,6 +30,7 @@ class App extends Component {
         <DevTools
           monitor={monitor}
           liftedState={liftedState}
+          monitorState={this.props.monitorState}
           dispatch={this.props.liftedDispatch}
           testComponent={options.lib === 'redux' && TestGenerator}
         />
@@ -66,6 +67,7 @@ App.propTypes = {
   getReport: PropTypes.func.isRequired,
   selected: PropTypes.string,
   liftedState: PropTypes.object.isRequired,
+  monitorState: PropTypes.object,
   options: PropTypes.object.isRequired,
   monitor: PropTypes.string,
   dispatcherIsOpen: PropTypes.bool,
@@ -81,6 +83,7 @@ function mapStateToProps(state) {
   return {
     selected: instances.selected,
     liftedState: instances.states[id],
+    monitorState: state.monitor.monitorState,
     options: instances.options[id],
     monitor: state.monitor.selected,
     dispatcherIsOpen: state.monitor.dispatcherIsOpen,

--- a/src/app/containers/DevTools.js
+++ b/src/app/containers/DevTools.js
@@ -38,6 +38,7 @@ export default class DevTools extends Component {
     return (
       nextProps.monitor !== this.props.monitor ||
       nextProps.liftedState !== this.props.liftedState ||
+      nextProps.monitorState !== this.props.liftedState ||
       nextProps.testComponent !== this.props.testComponent
     );
   }
@@ -51,10 +52,15 @@ export default class DevTools extends Component {
       this.preventRender = false;
       return null;
     }
+
+    const liftedState = {
+      ...this.props.liftedState,
+      monitorState: this.props.monitorState
+    };
     return (
       <this.Monitor
         dispatch={this.dispatch}
-        {...this.props.liftedState}
+        {...liftedState}
         {...this.monitorProps}
       />
     );
@@ -63,6 +69,7 @@ export default class DevTools extends Component {
 
 DevTools.propTypes = {
   liftedState: PropTypes.object,
+  monitorState: PropTypes.object,
   dispatch: PropTypes.func.isRequired,
   monitor: PropTypes.string,
   testComponent: PropTypes.oneOfType([

--- a/src/app/reducers/monitor.js
+++ b/src/app/reducers/monitor.js
@@ -1,13 +1,26 @@
-import { SELECT_MONITOR, TOGGLE_SLIDER, TOGGLE_DISPATCHER } from '../constants/actionTypes';
+import {
+  MONITOR_ACTION, SELECT_MONITOR, TOGGLE_SLIDER, TOGGLE_DISPATCHER
+} from '../constants/actionTypes';
 
 const initialState = {
   selected: 'InspectorMonitor',
+  monitorState: undefined,
   sliderIsOpen: true,
   dispatcherIsOpen: false
 };
 
+export function dispatchMonitorAction(state, action) {
+  return {
+    ...state,
+    monitorState: action.action.newMonitorState ||
+      action.monitorReducer(action.monitorProps, state.monitorState, action.action)
+  };
+}
+
 export default function monitor(state = initialState, action) {
   switch (action.type) {
+    case MONITOR_ACTION:
+      return dispatchMonitorAction(state, action);
     case SELECT_MONITOR:
       return {
         ...state,


### PR DESCRIPTION
It adds compatibility with Redux Devtools monitors by not ignoring its reducers as before. The difference, however, is that the reducers are called not for every action, but only when a monitor action is dispatched.