### PR TITLE
Support __serializedType__ inside actions

### DIFF
--- a/src/app/reducers/instances.js
+++ b/src/app/reducers/instances.js
@@ -42,7 +42,7 @@ function updateState(state, request, id, serialize) {
 
   let newState;
   const liftedState = state[id] || state.default;
-  const action = request.action && parseJSON(request.action) || {};
+  const action = request.action && parseJSON(request.action, serialize) || {};
 
   switch (request.type) {
     case 'INIT':


### PR DESCRIPTION
Currently __serializedType__ seems to be supported only inside state, but does not work for actions.

